### PR TITLE
Fix page unable to scroll after navigating through the menu dialog on mobile

### DIFF
--- a/components/global/Navbar.tsx
+++ b/components/global/Navbar.tsx
@@ -7,12 +7,8 @@ import { usePathname } from "next/navigation"
 
 import {
   Drawer,
-  DrawerClose,
   DrawerContent,
-  DrawerDescription,
   DrawerFooter,
-  DrawerHeader,
-  DrawerTitle,
   DrawerTrigger,
 } from "@/components/ui/drawer"
 
@@ -29,6 +25,7 @@ export default function Navbar({ offsetSpace = true, hideOnScroll = true }) {
   let menuButton: string = "hover:text-light-grey transition-colors text-lg"
 
   const [show, setShow] = useState(true)
+  const [openHamburger, setOpenHamburger] = useState(false)
   const [lastScrollY, setLastScrollY] = useState(0)
 
   const controlNavbar = () => {
@@ -60,6 +57,10 @@ export default function Navbar({ offsetSpace = true, hideOnScroll = true }) {
     return `hover:text-gray-600 transition-colors text-lg ${isActive ? "text-vgdc-light-green" : ""}`
   }
 
+  const closeHamburger = () => {
+    setOpenHamburger(false)
+  }
+
   return (
     <>
       {/* Physically include navbar in page? */}
@@ -83,7 +84,7 @@ export default function Navbar({ offsetSpace = true, hideOnScroll = true }) {
 
           {/* Hamburger menu for mobile, disappears on bigger screens */}
           <div className="absolute right-7 top-3 sm:hidden">
-            <Drawer>
+            <Drawer open={openHamburger} onOpenChange={setOpenHamburger}>
               {/* Hamburger icon */}
 
               <DrawerTrigger>
@@ -105,19 +106,39 @@ export default function Navbar({ offsetSpace = true, hideOnScroll = true }) {
                   {/* <Button variant="link" className={getStyle("/")}>
                     <Link href="/">Home</Link>
                   </Button> */}
-                  <Button variant="link" className={getStyle("/officers")}>
+                  <Button
+                    variant="link"
+                    className={getStyle("/officers")}
+                    onClick={closeHamburger}
+                  >
                     <Link href="/officers">Team</Link>
                   </Button>
-                  <Button variant="link" className={getStyle("/events")}>
+                  <Button
+                    variant="link"
+                    className={getStyle("/events")}
+                    onClick={closeHamburger}
+                  >
                     <Link href="/events">Events</Link>
                   </Button>
-                  <Button variant="link" className={getStyle("/games")}>
+                  <Button
+                    variant="link"
+                    className={getStyle("/games")}
+                    onClick={closeHamburger}
+                  >
                     <Link href="/games">Games</Link>
                   </Button>
-                  <Button variant="link" className={getStyle("/news")}>
+                  <Button
+                    variant="link"
+                    className={getStyle("/news")}
+                    onClick={closeHamburger}
+                  >
                     <Link href="/news">News</Link>
                   </Button>
-                  <Button variant="link" className={getStyle("/store")}>
+                  <Button
+                    variant="link"
+                    className={getStyle("/store")}
+                    onClick={closeHamburger}
+                  >
                     <Link href="/store">Store</Link>
                   </Button>
                 </DrawerFooter>


### PR DESCRIPTION
## Issue
On mobile, after opening the hamburger menu, clicking on a link, and being redirected, the page cannot be scrolled.

## Cause
- Opening the menu sets the `body` component's style to `position: fixed` to disable scrolling, which is undone when the menu is closed
- After navigating to a different page, React hydrates the page without reloading the `body`, keeping its `position: fixed` style


## Fix
- Now, each link/button in the menu also closes the dialog to unset the `body`'s style.