### PR TITLE
Fix/blog title wrap misalign

### DIFF
--- a/components/news/NewsBlogCard.tsx
+++ b/components/news/NewsBlogCard.tsx
@@ -44,7 +44,7 @@ export default function NewsBlogCard({
       </div>
 
       <div className="pl-0">
-        <h2 className="overflow-ellipsis text-2xl font-bold text-white md:truncate lg:text-wrap lg:text-2xl">
+        <h2 className="overflow-ellipsis text-2xl font-bold text-white md:truncate lg:text-wrap lg:text-2xl md:w-[26rem] lg:w-[28rem]">
           {post.title}
         </h2>
 

--- a/components/news/NewsBlogCard.tsx
+++ b/components/news/NewsBlogCard.tsx
@@ -44,7 +44,7 @@ export default function NewsBlogCard({
       </div>
 
       <div className="pl-0">
-        <h2 className="overflow-ellipsis text-2xl font-bold text-white md:truncate lg:text-wrap lg:text-2xl md:w-[26rem] lg:w-[28rem]">
+        <h2 className="text-2xl font-bold text-white lg:text-2xl md:w-[26rem] lg:w-[28rem]">
           {post.title}
         </h2>
 


### PR DESCRIPTION
<img width="1500" height="903" alt="Screenshot 2026-05-27 at 14 26 22" src="https://github.com/user-attachments/assets/91496ff2-e381-4def-9f49-86d6415c33a8" />
