### PR TITLE
Center officers on mobile

### DIFF
--- a/app/officers/Officers.tsx
+++ b/app/officers/Officers.tsx
@@ -89,7 +89,7 @@ function OfficerAnim( { order, children }: { order: number, children: React.Reac
         ease: "easeOut",
         duration: 0.6,
       }}
-      className="w-44"
+      className="w-44 flex flex-col items-center"
     >
       {children}
     </motion.div>


### PR DESCRIPTION
## Issue
Not all officer listings are centered on mobile.
<img width="1320" height="2510" alt="IMG_6571" src="https://github.com/user-attachments/assets/3f280070-86b4-4289-88af-54359ff55e64" />

## Fix
<img width="1320" height="2534" alt="IMG_6573" src="https://github.com/user-attachments/assets/e153d357-36e1-4daa-8aeb-177dccb4808c" />